### PR TITLE
sw: add data grid grouping elements

### DIFF
--- a/src/wc-sortable-table.js
+++ b/src/wc-sortable-table.js
@@ -141,12 +141,15 @@ export class WCSortableTable extends HTMLElement {
       this.__headers.appendChild(th);
     });
     this.styleHeaders();
-    table.appendChild(this.__headers);
+    const thead = document.createElement('thead');
+    thead.appendChild(this.__headers);
+    table.appendChild(thead);
 
     // sort the values
     data = this.sortData(data);
 
     // build the data rows
+    const tbody = document.createElement('tbody');
     data.forEach(row => {
       const tr = document.createElement('tr');
       row.forEach(cell => {
@@ -154,8 +157,9 @@ export class WCSortableTable extends HTMLElement {
         td.innerText = cell;
         tr.appendChild(td);
       });
-      table.appendChild(tr);
+      tbody.appendChild(tr);
     });
+    table.appendChild(tbody);
 
     if (this.__theme) {
       this.shadowRoot.removeChild(this.__table);


### PR DESCRIPTION
Prior to this commit, Semantic Web grouping elements were missing.

* Encapsulate elements with thead & tbody

I ended up playing with this component for quite a while and I realized that I had changed way too much for you to review in a single PR, so I'll be breaking into chunks. This first one should be simple enough and hopefully non-controversial.